### PR TITLE
Fix towers not looking at target

### DIFF
--- a/animgraphs/base_tower_anim.vanmgrph
+++ b/animgraphs/base_tower_anim.vanmgrph
@@ -9,6 +9,61 @@
 			{
 				key = 
 				{
+					m_id = 87783558
+				}
+				value = 
+				{
+					_class = "CLookAtAnimNode"
+					m_sName = "Aim Head"
+					m_vecPosition = [ 464.0, -64.0 ]
+					m_nNodeID = 
+					{
+						m_id = 87783558
+					}
+					m_networkMode = "ServerAuthoritative"
+					m_sNote = ""
+					m_inputConnection = 
+					{
+						m_nodeID = 
+						{
+							m_id = 2132006355
+						}
+						m_outputID = 
+						{
+							m_id = 4294967295
+						}
+					}
+					m_target = "VectorParameter"
+					m_param = 
+					{
+						m_id = 735848024
+					}
+					m_weightParam = 
+					{
+						m_id = 251493743
+					}
+					m_lookatChainName = "head"
+					m_attachmentName = "forward"
+					m_flYawLimit = 180.0
+					m_flPitchLimit = 0.0
+					m_bResetBase = true
+					m_bLockWhenWaning = false
+					m_bUseHysteresis = false
+					m_flHysteresisInnerAngle = 1.0
+					m_flHysteresisOuterAngle = 5.0
+					m_damping = 
+					{
+						_class = "CAnimInputDamping"
+						m_speedFunction = "NoDamping"
+						m_fSpeedScale = 20.0
+						m_fMinSpeed = 10.0
+						m_fMaxTension = 1000.0
+					}
+				}
+			},
+			{
+				key = 
+				{
 					m_id = 193985929
 				}
 				value = 
@@ -92,67 +147,12 @@
 					{
 						m_nodeID = 
 						{
-							m_id = 1901020746
+							m_id = 87783558
 						}
 						m_outputID = 
 						{
 							m_id = 4294967295
 						}
-					}
-				}
-			},
-			{
-				key = 
-				{
-					m_id = 1901020746
-				}
-				value = 
-				{
-					_class = "CLookAtAnimNode"
-					m_sName = "Unnamed"
-					m_vecPosition = [ 464.0, -64.0 ]
-					m_nNodeID = 
-					{
-						m_id = 1901020746
-					}
-					m_networkMode = "ServerAuthoritative"
-					m_sNote = ""
-					m_inputConnection = 
-					{
-						m_nodeID = 
-						{
-							m_id = 2132006355
-						}
-						m_outputID = 
-						{
-							m_id = 4294967295
-						}
-					}
-					m_target = "VectorParameter"
-					m_param = 
-					{
-						m_id = 735848024
-					}
-					m_weightParam = 
-					{
-						m_id = 251493743
-					}
-					m_lookatChainName = "lookhead"
-					m_attachmentName = "forward"
-					m_flYawLimit = 0.0
-					m_flPitchLimit = 180.0
-					m_bResetBase = false
-					m_bLockWhenWaning = false
-					m_bUseHysteresis = false
-					m_flHysteresisInnerAngle = 1.0
-					m_flHysteresisOuterAngle = 20.0
-					m_damping = 
-					{
-						_class = "CAnimInputDamping"
-						m_speedFunction = "Spring"
-						m_fSpeedScale = 20.0
-						m_fMinSpeed = 10.0
-						m_fMaxTension = 1000.0
 					}
 				}
 			},

--- a/code/Towers/Types/RangedTowers.cs
+++ b/code/Towers/Types/RangedTowers.cs
@@ -7,6 +7,8 @@ public partial class Pistol : BaseTower
 	public override string TowerName => "Pistol";
 	public override string TowerDesc => "A very simple pistol tower";
 
+	public Vector3 TargetDirection { get; private set; }
+
 	//Temporary until we get a pistol model
 	public override string TowerModel => "models/towers/pistol_tower.vmdl";
 	public override int UnlockLevel => 0;
@@ -52,8 +54,10 @@ public partial class Pistol : BaseTower
 
 		if ( IsPreviewing ) return;
 
-		//if ( Target != null && Target.IsValid() )
-			//SetAnimParameter( "v_forward", Owner.Position.WithZ(10) );
+		if ( Target != null && Target.IsValid() ) {
+			TargetDirection = TargetDirection.LerpTo( (Target.Position - GetAttachment( "forward" ).Value.Position).Normal, Time.Delta * 10f );
+			SetAnimParameter( "v_forward", TargetDirection );
+		}
 
 		SetAnimParameter( "b_attack", (TimeLastAttack + 0.1f) >= AttackTime && Target != null );
 	}
@@ -81,6 +85,8 @@ public partial class SMG : BaseTower
 		"A more improved version with a spinning barrel",
 		"A very fast spinning smg, don't mess with it"
 	};
+
+	public Vector3 TargetDirection { get; private set; }
 
 	public override List<(float AttTime, float AttDMG, int NewRange)> Upgrades => new()
 	{
@@ -111,8 +117,10 @@ public partial class SMG : BaseTower
 	{
 		base.SimulateTower();
 
-		//if ( Target != null && Target.IsValid() )
-		//	SetAnimParameter( "v_forward", GetAttachment( "forward" ).Value.Position + Target.Position );
+		if ( Target != null && Target.IsValid() ) {
+			TargetDirection = TargetDirection.LerpTo( (Target.Position - GetAttachment( "forward" ).Value.Position).Normal, Time.Delta * 10f );
+			SetAnimParameter( "v_forward", TargetDirection );
+		}
 
 		SetAnimParameter( "b_attack", (TimeLastAttack + 0.1f) >= AttackTime && Target != null );
 	}

--- a/models/towers/pistol_tower.vmdl
+++ b/models/towers/pistol_tower.vmdl
@@ -102,7 +102,7 @@
 				[
 					{
 						_class = "LookAtChain"
-						name = "lookhead"
+						name = "head"
 						lookat_chain = 
 						{
 							name = ""
@@ -110,7 +110,15 @@
 							[
 								{
 									name = "head"
-									weight = 0.6
+									weight = 1.0
+								},
+								{
+									name = "barrel"
+									weight = 0.0
+								},
+								{
+									name = "muzze"
+									weight = 0.0
 								},
 							]
 						}
@@ -148,11 +156,11 @@
 					{
 						_class = "Attachment"
 						name = "forward"
-						parent_bone = "barrel"
+						parent_bone = "muzzel"
 						relative_origin = [ 0.0, 0.0, 0.0 ]
-						relative_angles = [ 0.0, 0.0, 90.0 ]
+						relative_angles = [ 0.0, 90.0, 0.0 ]
 						weight = 1.0
-						ignore_rotation = true
+						ignore_rotation = false
 					},
 				]
 			},

--- a/models/towers/smgtower.vmdl
+++ b/models/towers/smgtower.vmdl
@@ -128,8 +128,8 @@
 						_class = "Attachment"
 						name = "forward"
 						parent_bone = "head"
-						relative_origin = [ 0.0, 0.0, 0.0 ]
-						relative_angles = [ 0.0, 0.0, 90.0 ]
+						relative_origin = [ 0.0, 75.0, 0.0 ]
+						relative_angles = [ 0.0, 90.0, 0.0 ]
 						weight = 1.0
 						ignore_rotation = false
 					},
@@ -225,7 +225,7 @@
 							[
 								{
 									name = "head"
-									weight = 0.6
+									weight = 1.0
 								},
 								{
 									name = "barrel_l"


### PR DESCRIPTION
Tested in game and this makes the pistol and smg aim at enemies correctly
Reverted some changes in 041597292e76bbe28cb383fd444fc0c5ee5af899
The shotgun model will need to be updated to have bones, so the shotgun is still static.
The Lerp function smooths out the rotation a tiny bit, so it doesn't instantly snap to a target with no feeling of motion - though it is still almost instant. If this number is ever to be reduced, I think a system would need to be in place to detect if the tower is looking at it's target before shooting.
I've also removed the damping in animgraph, as it was causing an issue where the turret would do a 359 degree spin when going past the 180 degree threshold.